### PR TITLE
Adds ability to limit or deny services and applications.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -37,10 +37,35 @@ provisioner:
         enabled: True
         settings:
           loglevel: 'low'
+        applications:
+          MySQL:
+            comment: Allow MySQL
+          Postgresql:
+            limit: True
+            comment: Limit Postgresql
+          SSH223:
+            deny: True
+            comment: Deny Webscale SSH
+          '*':
+            deny: True
+            from_addr: 10.0.0.0/8
         services:
+          '*':
+            deny: True
+            from_addr:
+              - 10.0.0.1
+              - 10.0.0.2
           '22':
             protocol: tcp
-            comment: Allow SSH
+            limit: True
+            comment: Limit SSH
+          '80':
+            protocol: tcp
+            deny: True
+            comment: Deny HTTP
+          '443':
+            protocol: tcp
+            comment: Allow HTTPS
 
 platforms:
   - name: <%= distrib %>-<%= codename %>

--- a/_states/ufw.py
+++ b/_states/ufw.py
@@ -100,6 +100,7 @@ def _add_rule(method, name, app=None, interface=None, protocol=None,
         return _error(name, e.message)
 
     adds = False
+    inserts = False
     updates = False
     for line in out.split('\n'):
         if re.match('^Skipping', line):
@@ -107,6 +108,9 @@ def _add_rule(method, name, app=None, interface=None, protocol=None,
             break
         if re.match('^Rule(s)? added', line):
             adds = True
+            break
+        if re.match('^Rule(s)? inserted', line):
+            inserts = True
             break
         if re.match('^Rule(s)? updated', line):
             updates = True
@@ -122,6 +126,8 @@ def _add_rule(method, name, app=None, interface=None, protocol=None,
 
     if adds:
         return _changed(name, "{0} added".format(name), rule=rule)
+    elif inserts:
+        return _changed(name, "{0} inserted".format(name), rule=rule)
     elif updates:
         return _changed(name, "{0} updated".format(name), rule=rule)
     else:

--- a/_states/ufw.py
+++ b/_states/ufw.py
@@ -80,6 +80,47 @@ def _as_rule(method, app, interface, protocol, from_addr, from_port, to_addr, to
     return real_cmd
 
 
+def _add_rule(method, name, app=None, interface=None, protocol=None,
+              from_addr=None, from_port=None, to_addr=None, to_port=None, comment=None):
+
+    if app and app.strip('"\' ') == '*':
+        app = None
+    if to_port and to_port.strip('"\' ') == '*':
+        to_port = None
+
+    rule = _as_rule(method, app=app, interface=interface, protocol=protocol,
+                    from_addr=from_addr, from_port=from_port, to_addr=to_addr, to_port=to_port, comment=comment)
+
+    try:
+        out = __salt__['ufw.add_rule'](rule)
+    except (CommandExecutionError, CommandNotFoundError) as e:
+        return _error(name, e.message)
+
+    adds = False
+    updates = False
+    for line in out.split('\n'):
+        if re.match('^Skipping', line):
+            return _unchanged(name, "{0} is already configured".format(name))
+            break
+        if re.match('^Rule(s)? added', line):
+            adds = True
+            break
+        if re.match('^Rule(s)? updated', line):
+            updates = True
+            break
+        if __opts__['test']:
+            return _test(name, "{0} would have been configured".format(name))
+            break
+        return _error(name, line)
+
+    if adds:
+        return _changed(name, "{0} added".format(name), rule=rule)
+    elif updates:
+        return _changed(name, "{0} updated".format(name), rule=rule)
+    else:
+        return _unchanged(name, "{0} was already configured".format(name))
+
+
 def enabled(name, **kwargs):
     if __salt__['ufw.is_enabled']():
         return _unchanged(name, "UFW is already enabled")
@@ -137,38 +178,28 @@ def default_outgoing(name, default):
     return _unchanged(name, "{0} was already set to {1}".format(name, default))
 
 
+def deny(name, app=None, interface=None, protocol=None,
+         from_addr=None, from_port=None, to_addr=None, to_port=None, comment=None):
+
+    return _add_rule('deny', name, app, interface, protocol, from_addr, from_port, to_addr, to_port, comment)
+
+
+def limit(name, app=None, interface=None, protocol=None,
+          from_addr=None, from_port=None, to_addr=None, to_port=None, comment=None):
+
+    return _add_rule('limit', name, app, interface, protocol, from_addr, from_port, to_addr, to_port, comment)
+
+
+def allow(name, app=None, interface=None, protocol=None,
+          from_addr=None, from_port=None, to_addr=None, to_port=None, comment=None):
+
+    return _add_rule('allow', name, app, interface, protocol, from_addr, from_port, to_addr, to_port, comment)
+
+
 def allowed(name, app=None, interface=None, protocol=None,
             from_addr=None, from_port=None, to_addr=None, to_port=None, comment=None):
 
-    rule = _as_rule("allow", app=app, interface=interface, protocol=protocol,
-                   from_addr=from_addr, from_port=from_port, to_addr=to_addr, to_port=to_port, comment=comment)
-
-    try:
-        out = __salt__['ufw.add_rule'](rule)
-    except (CommandExecutionError, CommandNotFoundError) as e:
-        return _error(name, e.message)
-
-    adds = False
-    updates = False
-    for line in out.split('\n'):
-        if re.match('^Skipping', line):
-            return _unchanged(name, "{0} is already configured".format(name))
-            break
-        if re.match('^Rule(s)? added', line):
-            adds = True
-            break
-        if re.match('^Rule(s)? updated', line):
-            updates = True
-            break
-        if __opts__['test']:
-            return _test(name, "{0} would have been configured".format(name))
-            break
-        return _error(name, line)
-
-    if adds:
-        return _changed(name, "{0} added".format(name), rule=rule)
-    elif updates:
-        return _changed(name, "{0} updated".format(name), rule=rule)
-    else:
-        return _unchanged(name, "{0} was already configured".format(name))
-
+    """
+    allow() is aliased to allowed() to maintain backwards compatibility.
+    """
+    return allow(name, app, interface, protocol, from_addr, from_port, to_addr, to_port, comment)

--- a/pillar.example
+++ b/pillar.example
@@ -53,10 +53,35 @@ ufw:
       protocol: tcp
       comment: Mail relay
 
-    # Allow from an specific port, by number.
+    # Allow from a specific port, by number.
     139:
       protocol: tcp
       comment: Netbios
+
+    # Deny from a specific port, by number.
+    140:
+      protocol: tcp
+      deny: True
+
+    # Deny everything from a specific ip address
+    '*':
+      protocol: tcp
+      deny: True
+      from_addr: 10.0.0.1
+
+    # Deny everything from a multiple ip addresses
+    '*':
+      protocol: tcp
+      deny: True
+      from_addr:
+        - 10.0.0.2
+        - 10.0.0.3
+
+    # Limit a specific port, by number.
+    170:
+      limit: True
+      protocol: tcp
+      comment: Print service
 
     # Allow from a range of ports, udp.
     "10000:20000":
@@ -68,11 +93,19 @@ ufw:
       protocol: udp
       comment: Game server and admin
 
-  # Allow an application defined at /etc/ufw/applications.d/
+  # Allow applications defined at /etc/ufw/applications.d/
   applications:
     OpenSSH:
       enabled: True
       comment: We are using fail2ban anyway
+
+    # Limit access to salt master
+    Saltmaster:
+      limit: True
+
+    # Deny access to Postgresql
+    Postgresql:
+      deny: True
 
   # Allow all traffic in on the specified interface
   interfaces:

--- a/test/integration/ufw/controls/ufw.rb
+++ b/test/integration/ufw/controls/ufw.rb
@@ -25,7 +25,47 @@ describe command('ufw status verbose | grep Logging') do
   its('stdout') { should match /low/ }
 end
 
-describe command('ufw status | grep 22/tcp') do
+describe command('ufw status | grep MySQL') do
   its('exit_status') { should eq 0 }
   its('stdout') { should match /ALLOW/ }
+end
+
+describe command('ufw status | grep Postgresql') do
+  its('exit_status') { should eq 0 }
+  its('stdout') { should match /LIMIT/ }
+end
+
+describe command('ufw status | grep SSH223') do
+  its('exit_status') { should eq 0 }
+  its('stdout') { should match /DENY/ }
+end
+
+describe command('ufw status | grep 10.0.0.0') do
+  its('exit_status') { should eq 0 }
+  its('stdout') { should match /DENY/ }
+end
+
+describe command('ufw status | grep 22/tcp') do
+  its('exit_status') { should eq 0 }
+  its('stdout') { should match /LIMIT/ }
+end
+
+describe command('ufw status | grep 80/tcp') do
+  its('exit_status') { should eq 0 }
+  its('stdout') { should match /DENY/ }
+end
+
+describe command('ufw status | grep 443/tcp') do
+  its('exit_status') { should eq 0 }
+  its('stdout') { should match /ALLOW/ }
+end
+
+describe command('ufw status | grep 10.0.0.1') do
+  its('exit_status') { should eq 0 }
+  its('stdout') { should match /DENY/ }
+end
+
+describe command('ufw status | grep 10.0.0.2') do
+  its('exit_status') { should eq 0 }
+  its('stdout') { should match /DENY/ }
 end


### PR DESCRIPTION
The `limit` and `deny` parameters have been added to both the `services` and
`applications` sections. Setting `limit: True` will use the `ufw limit` command
instead of `ufw allow`. Likewise, setting `deny: True` will use the `ufw deny`
command.

Includes tests and pillar examples for the new parameters.