### PR TITLE
Also perform tests on bionic/18.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ env:
   matrix:
     - DISTRIB=debian:stretch/9
     - DISTRIB=ubuntu:xenial/16.04
+    - DISTRIB=ubuntu:bionic/18.04


### PR DESCRIPTION
We can enable tests on Ubuntu Bionic 18.04 LTS, now that SaltStack 2018.3.1 is out and provides packages for this distribution.