### PR TITLE
Allow multiple configurations for the same port

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,18 @@ ufw:
       protocol: udp
 ```
 
+Allow from a range of ports, tcp and udp
+```
+ufw:
+  services:
+    "10000:20000/tcp":
+      to_port: "10000:20000"
+      protocol: tcp
+    "10000:20000/udp":
+      to_port: "10000:20000"
+      protocol: udp
+```
+
 Allow from two specific ports, udp:
 ```
 ufw:

--- a/pillar.example
+++ b/pillar.example
@@ -69,8 +69,10 @@ ufw:
       deny: True
       from_addr: 10.0.0.1
 
-    # Deny everything from a multiple ip addresses
-    '*':
+    # Deny everything from multiple ip addresses and avoid
+    # conflicts with already defined service '*'
+    '*/multiple':
+      to_port: '*'
       protocol: tcp
       deny: True
       from_addr:

--- a/ufw/init.sls
+++ b/ufw/init.sls
@@ -53,6 +53,7 @@ ufw:
       {%- set method    = 'deny' if deny else ('limit' if limit else 'allow') -%}
       {%- set from_port = service_details.get('from_port', None) %}
       {%- set to_addr   = service_details.get('to_addr', None) %}
+      {%- set to_port   = service_details.get('to_port', service_name) %}
       {%- set comment   = service_details.get('comment', None) %}
 
 ufw-svc-{{method}}-{{service_name}}-{{from_addr}}:
@@ -72,7 +73,7 @@ ufw-svc-{{method}}-{{service_name}}-{{from_addr}}:
     {%- if comment != None %}
     - comment: '"{{comment}}"'
     {%- endif %}
-    - to_port: "{{service_name}}"
+    - to_port: "{{to_port}}"
     - require:
       - pkg: ufw
     - listen_in:


### PR DESCRIPTION
Sometimes I need different configurations for the same port(s). The most common example of this is probably allowing access to a port range via both TCP and UDP.

Unfortunately, this isn't possible when the port range is used as the dictionary key, so this PR adds an optional property `to_port` which overrides the value of `service_name`. This allows me to add two services `123:456/tcp` and `123:456/udp` with different configurations and set `to_port` to `123:456` for both.

I also updated the README.md and pillar.example files.