### PR TITLE
feat(yamllint): include for this repo and apply rules throughout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 ---
 stages:
   - test
-  - commitlint
+  - lint
   - name: release
     if: branch = master AND type != pull_request
 
@@ -45,16 +45,21 @@ script:
 
 jobs:
   include:
-    # Define the commitlint stage
-    - stage: commitlint
+    # Define the `lint` stage (runs `yamllint` and `commitlint`)
+    - stage: lint
       language: node_js
       node_js: lts/*
       before_install: skip
       script:
+        # Install and run `yamllint`
+        - pip install --user yamllint
+        # yamllint disable-line rule:line-length
+        - yamllint -s . .yamllint pillar.example test/salt/pillar/default.sls
+        # Install and run `commitlint`
         - npm install @commitlint/config-conventional -D
         - npm install @commitlint/travis-cli -D
         - commitlint-travis
-    # Define the release stage that runs semantic-release
+    # Define the release stage that runs `semantic-release`
     - stage: release
       language: node_js
       node_js: lts/*

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
+# Extend the `default` configuration provided by `yamllint`
+extends: default
+
+# Files to ignore completely
+# 1. All YAML files under directory `node_modules/`, introduced during the Travis run
+ignore: |
+  node_modules/
+
+rules:
+  line-length:
+    # Increase from default of `80`
+    # Based on https://github.com/PyCQA/flake8-bugbear#opinionated-warnings (`B950`)
+    max: 88

--- a/pillar.example
+++ b/pillar.example
@@ -1,15 +1,18 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 ufw:
 
-  enabled: True
+  enabled: true
 
   settings:
     loglevel: low
-    ipv6: True
+    ipv6: true
     default_input_policy: 'DROP'
     default_output_policy: 'ACCEPT'
     default_forward_policy: 'DROP'
     default_application_policy: 'SKIP'
-    manage_builtins: False
+    manage_builtins: false
     ipt_sysctl: '/etc/ufw/sysctl.conf'
     ipt_modules:
       - nf_conntrack_ftp
@@ -61,12 +64,12 @@ ufw:
     # Deny from a specific port, by number.
     140:
       protocol: tcp
-      deny: True
+      deny: true
 
     # Deny everything from a specific ip address
     '*':
       protocol: tcp
-      deny: True
+      deny: true
       from_addr: 10.0.0.1
 
     # Deny everything from multiple ip addresses and avoid
@@ -74,14 +77,14 @@ ufw:
     '*/multiple':
       to_port: '*'
       protocol: tcp
-      deny: True
+      deny: true
       from_addr:
         - 10.0.0.2
         - 10.0.0.3
 
     # Limit a specific port, by number.
     170:
-      limit: True
+      limit: true
       protocol: tcp
       comment: Print service
 
@@ -98,16 +101,16 @@ ufw:
   # Allow applications defined at /etc/ufw/applications.d/
   applications:
     OpenSSH:
-      enabled: True
+      enabled: true
       comment: We are using fail2ban anyway
 
     # Limit access to salt master
     Saltmaster:
-      limit: True
+      limit: true
 
     # Deny access to Postgresql
     Postgresql:
-      deny: True
+      deny: true
 
   # Allow all traffic in on the specified interface
   interfaces:

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 name: default
 title: ufw formula
 maintainer: SaltStack Formulas

--- a/test/salt/pillar/default.sls
+++ b/test/salt/pillar/default.sls
@@ -1,32 +1,35 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 ufw:
-  enabled: True
+  enabled: true
   settings:
     loglevel: 'low'
   applications:
     MySQL:
       comment: Allow MySQL
     Postgresql:
-      limit: True
+      limit: true
       comment: Limit Postgresql
     SSH223:
-      deny: True
+      deny: true
       comment: Deny Webscale SSH
     '*':
-      deny: True
+      deny: true
       from_addr: 10.0.0.0/8
   services:
     '*':
-      deny: True
+      deny: true
       from_addr:
         - 10.0.0.1
         - 10.0.0.2
     '22':
       protocol: tcp
-      limit: True
+      limit: true
       comment: Limit SSH
     '80':
       protocol: tcp
-      deny: True
+      deny: true
       comment: Deny HTTP
     '443':
       protocol: tcp


### PR DESCRIPTION
* Semi-automated using `ssf-formula` (v0.5.0)
* Fix errors shown below:

```bash
ufw-formula$ $(grep "\- yamllint" .travis.yml | sed -e "s:^\s\+-\s\(.*\):\1:")
pillar.example
  1:1       warning  missing document start "---"  (document-start)
  3:12      warning  truthy value should be one of [false, true]  (truthy)
  7:11      warning  truthy value should be one of [false, true]  (truthy)
  12:22     warning  truthy value should be one of [false, true]  (truthy)
  64:13     warning  truthy value should be one of [false, true]  (truthy)
  69:13     warning  truthy value should be one of [false, true]  (truthy)
  77:13     warning  truthy value should be one of [false, true]  (truthy)
  84:14     warning  truthy value should be one of [false, true]  (truthy)
  101:16    warning  truthy value should be one of [false, true]  (truthy)
  106:14    warning  truthy value should be one of [false, true]  (truthy)
  110:13    warning  truthy value should be one of [false, true]  (truthy)

test/salt/pillar/default.sls
  1:1       warning  missing document start "---"  (document-start)
  2:12      warning  truthy value should be one of [false, true]  (truthy)
  9:14      warning  truthy value should be one of [false, true]  (truthy)
  12:13     warning  truthy value should be one of [false, true]  (truthy)
  15:13     warning  truthy value should be one of [false, true]  (truthy)
  19:13     warning  truthy value should be one of [false, true]  (truthy)
  25:14     warning  truthy value should be one of [false, true]  (truthy)
  29:13     warning  truthy value should be one of [false, true]  (truthy)
```

---

Refer back to: https://github.com/saltstack-formulas/template-formula/pull/159#issue-305203039.